### PR TITLE
Update README.md - Missed closing quote in the last entry of the 70-nvidia.rules file

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Add these lines
 ```
 KERNEL=="nvidia", RUN+="/bin/bash -c '/usr/bin/nvidia-smi -L && /bin/chmod 666 /dev/nvidia*'"
 KERNEL=="nvidia_modeset", RUN+="/bin/bash -c '/usr/bin/nvidia-modprobe -c0 -m && /bin/chmod 666 /dev/nvidia-modeset*'"
-KERNEL=="nvidia_uvm", RUN+="/bin/bash -c '/usr/bin/nvidia-modprobe -c0 -u && /bin/chmod 666 /dev/nvidia-uvm*'
+KERNEL=="nvidia_uvm", RUN+="/bin/bash -c '/usr/bin/nvidia-modprobe -c0 -u && /bin/chmod 666 /dev/nvidia-uvm*'"
 ```
 ![image](https://i.imgur.com/8UAEmJI.png)
 > These udev rules are setting the permissions and calling for the module files to be loaded into the kernel since this wasn't done by the nvidia driver installer.


### PR DESCRIPTION
…vidia.rules file

Quotation wasn't closed in the last entry suggested into /etc/udev/rules.d/70-nvidia.rules file. Need to update instructions to include that quote.

last entry should become
KERNEL=="nvidia_uvm", RUN+="/bin/bash -c '/usr/bin/nvidia-modprobe -c0 -u && /bin/chmod 666 /dev/nvidia-uvm*'"